### PR TITLE
Implement parser stream

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -322,18 +322,23 @@
 **Kind**: global class  
 
 * [X12Parser](#X12Parser)
-    * [new X12Parser([strict])](#new_X12Parser_new)
+    * [new X12Parser([strict], [encoding], [options])](#new_X12Parser_new)
     * [.parse(edi, [options])](#X12Parser+parse) ⇒ [<code>X12Interchange</code>](#X12Interchange) \| [<code>X12FatInterchange</code>](#X12FatInterchange)
+    * [.getInterchangeFromSegments(segments, [options])](#X12Parser+getInterchangeFromSegments) ⇒ [<code>X12Interchange</code>](#X12Interchange) \| [<code>X12FatInterchange</code>](#X12FatInterchange)
+    * [._flush(callback)](#X12Parser+_flush)
+    * [._transform(chunk, encoding, callback)](#X12Parser+_transform)
 
 <a name="new_X12Parser_new"></a>
 
-### new X12Parser([strict])
+### new X12Parser([strict], [encoding], [options])
 <p>Factory for parsing EDI into interchange object.</p>
 
 
 | Param | Type | Description |
 | --- | --- | --- |
-| [strict] | <code>boolean</code> | <p>Set true to strictly follow the EDI spec.</p> |
+| [strict] | <code>boolean</code> \| [<code>X12SerializationOptions</code>](#X12SerializationOptions) | <p>Set true to strictly follow the EDI spec; defaults to false.</p> |
+| [encoding] | <code>string</code> \| [<code>X12SerializationOptions</code>](#X12SerializationOptions) | <p>The encoding to use for this instance when parsing a stream; defaults to UTF-8.</p> |
+| [options] | [<code>X12SerializationOptions</code>](#X12SerializationOptions) | <p>The options to use when parsing a stream.</p> |
 
 <a name="X12Parser+parse"></a>
 
@@ -341,12 +346,49 @@
 <p>Parse an EDI document.</p>
 
 **Kind**: instance method of [<code>X12Parser</code>](#X12Parser)  
-**Returns**: [<code>X12Interchange</code>](#X12Interchange) \| [<code>X12FatInterchange</code>](#X12FatInterchange) - <p>An interchange or a fat interchange.</p>  
+**Returns**: [<code>X12Interchange</code>](#X12Interchange) \| [<code>X12FatInterchange</code>](#X12FatInterchange) - <p>An interchange or fat interchange.</p>  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | edi | <code>string</code> | <p>An ASCII or UTF8 string of EDI to parse.</p> |
 | [options] | [<code>X12SerializationOptions</code>](#X12SerializationOptions) | <p>Options for serializing from EDI.</p> |
+
+<a name="X12Parser+getInterchangeFromSegments"></a>
+
+### x12Parser.getInterchangeFromSegments(segments, [options]) ⇒ [<code>X12Interchange</code>](#X12Interchange) \| [<code>X12FatInterchange</code>](#X12FatInterchange)
+<p>Method for processing an array of segments into the node-x12 object model; typically used with the finished output of a stream.</p>
+
+**Kind**: instance method of [<code>X12Parser</code>](#X12Parser)  
+**Returns**: [<code>X12Interchange</code>](#X12Interchange) \| [<code>X12FatInterchange</code>](#X12FatInterchange) - <p>An interchange or fat interchange.</p>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| segments | [<code>Array.&lt;X12Segment&gt;</code>](#X12Segment) | <p>An array of X12Segment objects.</p> |
+| [options] | [<code>X12SerializationOptions</code>](#X12SerializationOptions) | <p>Options for serializing from EDI.</p> |
+
+<a name="X12Parser+_flush"></a>
+
+### x12Parser.\_flush(callback)
+<p>Flush method for Node API Transform stream.</p>
+
+**Kind**: instance method of [<code>X12Parser</code>](#X12Parser)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| callback | <code>function</code> | <p>Callback to execute when finished.</p> |
+
+<a name="X12Parser+_transform"></a>
+
+### x12Parser.\_transform(chunk, encoding, callback)
+<p>Transform method for Node API Transform stream.</p>
+
+**Kind**: instance method of [<code>X12Parser</code>](#X12Parser)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chunk | <code>object</code> | <p>A chunk of data from the read stream.</p> |
+| encoding | <code>string</code> | <p>Chunk enoding.</p> |
+| callback | <code>function</code> | <p>Callback signalling chunk is processed and instance is ready for next chunk.</p> |
 
 <a name="X12QueryEngine"></a>
 
@@ -525,7 +567,7 @@
     * [new X12Transaction([options])](#new_X12Transaction_new)
     * [.setHeader(elements, [options])](#X12Transaction+setHeader)
     * [.addSegment(tag, elements, [options])](#X12Transaction+addSegment) ⇒ [<code>X12Segment</code>](#X12Segment)
-    * [.fromObject(input, map, [macroObj])](#X12Transaction+fromObject) ⇒ <code>object</code>
+    * [.fromObject(input, map, [macro])](#X12Transaction+fromObject)
     * [.toObject(map, helper)](#X12Transaction+toObject) ⇒ <code>object</code>
     * [.toString([options])](#X12Transaction+toString) ⇒ <code>string</code>
     * [.toJSON()](#X12Transaction+toJSON) ⇒ <code>object</code>
@@ -568,17 +610,16 @@
 
 <a name="X12Transaction+fromObject"></a>
 
-### x12Transaction.fromObject(input, map, [macroObj]) ⇒ <code>object</code>
+### x12Transaction.fromObject(input, map, [macro])
 <p>Map data from a javascript object to this transaction set.</p>
 
 **Kind**: instance method of [<code>X12Transaction</code>](#X12Transaction)  
-**Returns**: <code>object</code> - <p>An object containing resolved values mapped to object keys.</p>  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | input | <code>object</code> | <p>The input object to create the transaction from.</p> |
 | map | <code>object</code> | <p>The javascript object containing keys and querys to resolve.</p> |
-| [macroObj] | <code>object</code> | <p>A macro object to add or override methods for the macro directive; properties 'header' and 'segments' are reserved words.</p> |
+| [macro] | <code>object</code> | <p>A macro object to add or override methods for the macro directive; properties 'header' and 'segments' are reserved words.</p> |
 
 <a name="X12Transaction+toObject"></a>
 

--- a/docs/Tests.md
+++ b/docs/Tests.md
@@ -205,6 +205,37 @@ const parser = new core_1.X12Parser(true);
 parser.parse(edi);
 ```
 
+should parse and reconstruct a valid X12 stream without throwing an error.
+
+```js
+async () => {
+        return new Promise((resolve, reject) => {
+            const ediStream = fs.createReadStream('test/test-data/850.edi', 'utf8');
+            const parser = new core_1.X12Parser();
+            const segments = [];
+            ediStream.on('error', (error) => {
+                reject(error);
+            });
+            parser.on('error', (error) => {
+                reject(error);
+            });
+            ediStream.pipe(parser).on('data', (data) => {
+                segments.push(data);
+            })
+                .on('end', () => {
+                const edi = fs.readFileSync('test/test-data/850.edi', 'utf8');
+                const interchange = parser.getInterchangeFromSegments(segments);
+                interchange.options.format = true;
+                interchange.options.endOfLine = '\n';
+                if (interchange.toString() !== edi) {
+                    reject(new Error('Expected parsed EDI stream to match raw EDI document.'));
+                }
+                resolve();
+            });
+        });
+    }
+```
+
 should produce accurate line numbers for files with line breaks.
 
 ```js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "node-x12",
-    "version": "1.2.2",
+    "version": "1.3.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-x12",
-    "version": "1.2.2",
+    "version": "1.3.0",
     "description": "A simple ASC X12 parser, generator, query engine, and mapper for NodeJS.",
     "main": "index.js",
     "keywords": [

--- a/src/X12Parser.ts
+++ b/src/X12Parser.ts
@@ -40,7 +40,12 @@ export class X12Parser extends Transform {
       options = encoding
       encoding = 'utf8'
     }
-    super({ objectMode: true, encoding })
+    super({
+      readableObjectMode: true,
+      writableObjectMode: true,
+      objectMode: true,
+      defaultEncoding: encoding
+    })
     this.diagnostics = new Array<X12Diagnostic>()
     this._strict = strict
     this._options = options
@@ -437,11 +442,13 @@ export class X12Parser extends Transform {
 
     if (Array.isArray(rawSegments)) {
       for (let i = 0; i < rawSegments.length; i += 1) {
-        const segments = this._parseSegments(rawSegments[i] + this._options.segmentTerminator, this._options.segmentTerminator, this._options.elementDelimiter)
+        if (rawSegments[i].length > 0) {
+          const segments = this._parseSegments(rawSegments[i] + this._options.segmentTerminator, this._options.segmentTerminator, this._options.elementDelimiter)
 
-        segments.forEach((segment) => {
-          this.push(segment)
-        })
+          segments.forEach((segment) => {
+            this.push(segment)
+          })
+        }
       }
     }
   }
@@ -455,7 +462,7 @@ export class X12Parser extends Transform {
     this._consumeChunk(this._dataCache)
     this._flushing = false
 
-    callback.call(this)
+    callback()
   }
 
   /**
@@ -467,6 +474,6 @@ export class X12Parser extends Transform {
   public _transform (chunk: any, encoding: string, callback: Function): void {
     this._consumeChunk(this._decoder.write(chunk))
 
-    callback.call(this)
+    callback()
   }
 }

--- a/src/X12Parser.ts
+++ b/src/X12Parser.ts
@@ -1,5 +1,7 @@
 'use strict'
 
+import { Transform } from 'stream'
+import { StringDecoder } from 'string_decoder'
 import { ArgumentNullError, ParserError } from './Errors'
 import { Range, Position } from './Positioning'
 import { X12Diagnostic, X12DiagnosticLevel } from './X12Diagnostic'
@@ -15,26 +17,56 @@ const DOCUMENT_MIN_LENGTH: number = 113 // ISA = 106, IEA > 7
 const SEGMENT_TERMINATOR_POS: number = 105
 const ELEMENT_DELIMITER_POS: number = 3
 const SUBELEMENT_DELIMITER_POS: number = 104
+const REPETITION_DELIMITER_POS: number = 82
 // Legacy note: const INTERCHANGE_CACHE_SIZE: number = 10
 
-export class X12Parser {
+export class X12Parser extends Transform {
   /**
    * @description Factory for parsing EDI into interchange object.
-   * @param {boolean} [strict] - Set true to strictly follow the EDI spec.
+   * @param {boolean|X12SerializationOptions} [strict] - Set true to strictly follow the EDI spec; defaults to false.
+   * @param {string|X12SerializationOptions} [encoding] - The encoding to use for this instance when parsing a stream; defaults to UTF-8.
+   * @param {X12SerializationOptions} [options] - The options to use when parsing a stream.
    */
-  constructor (strict?: boolean) {
+  constructor (strict?: boolean | X12SerializationOptions, encoding?: 'ascii' | 'utf8' | X12SerializationOptions, options?: X12SerializationOptions) {
+    if (strict === undefined) {
+      strict = false
+    } else if (typeof strict !== 'boolean') {
+      options = strict
+      strict = false
+    }
+    if (encoding === undefined) {
+      encoding = 'utf8'
+    } else if (typeof encoding !== 'string') {
+      options = encoding
+      encoding = 'utf8'
+    }
+    super({ objectMode: true, encoding })
     this.diagnostics = new Array<X12Diagnostic>()
     this._strict = strict
+    this._options = options
+    this._decoder = new StringDecoder(encoding)
+    this._parsedISA = false
+    this._flushing = false
+    this._dataCache = ''
   }
 
-  private readonly _strict: boolean;
-  diagnostics: X12Diagnostic[];
+  private readonly _strict: boolean
+  private readonly _decoder: StringDecoder
+  private _options: X12SerializationOptions
+  private _dataCache: string
+  private _parsedISA: boolean
+  private _flushing: boolean
+  private _fatInterchange: X12FatInterchange
+  private _interchange: X12Interchange
+  private _group: X12FunctionalGroup
+  private _transaction: X12Transaction
+  diagnostics: X12Diagnostic[]
 
   /**
    * @description Parse an EDI document.
    * @param {string} edi - An ASCII or UTF8 string of EDI to parse.
    * @param {X12SerializationOptions} [options] - Options for serializing from EDI.
-   * @returns {X12Interchange|X12FatInterchange} An interchange or a fat interchange.
+   * @returns {X12Interchange|X12FatInterchange} An interchange or fat interchange.
    */
   parse (edi: string, options?: X12SerializationOptions): X12Interchange | X12FatInterchange {
     if (edi === undefined) {
@@ -43,6 +75,42 @@ export class X12Parser {
 
     this.diagnostics.splice(0)
 
+    this._validateEdiLength(edi)
+
+    this._detectOptions(edi, options)
+
+    this._validateIsaLength(edi, this._options.elementDelimiter)
+
+    const segments = this._parseSegments(edi, this._options.segmentTerminator, this._options.elementDelimiter)
+
+    segments.forEach((segment) => {
+      this._processSegment(segment)
+    })
+
+    return this._fatInterchange === undefined
+      ? this._interchange
+      : this._fatInterchange
+  }
+
+  /**
+   * @description Method for processing an array of segments into the node-x12 object model; typically used with the finished output of a stream.
+   * @param {X12Segment[]} segments - An array of X12Segment objects.
+   * @param {X12SerializationOptions} [options] - Options for serializing from EDI.
+   * @returns {X12Interchange|X12FatInterchange} An interchange or fat interchange.
+   */
+  getInterchangeFromSegments (segments: X12Segment[], options?: X12SerializationOptions): X12Interchange | X12FatInterchange {
+    this._options = options === undefined ? this._options : defaultSerializationOptions(options)
+
+    segments.forEach((segment) => {
+      this._processSegment(segment)
+    })
+
+    return this._fatInterchange === undefined
+      ? this._interchange
+      : this._fatInterchange
+  }
+
+  private _validateEdiLength (edi: string): void {
     if (edi.length < DOCUMENT_MIN_LENGTH) {
       const errorMessage = `X12 Standard: Document is too short. Document must be at least ${DOCUMENT_MIN_LENGTH} characters long to be well-formed X12.`
 
@@ -52,24 +120,9 @@ export class X12Parser {
 
       this.diagnostics.push(new X12Diagnostic(X12DiagnosticLevel.Error, errorMessage, new Range(0, 0, 0, edi.length - 1)))
     }
+  }
 
-    let segmentTerminator = edi.charAt(SEGMENT_TERMINATOR_POS)
-    let elementDelimiter = edi.charAt(ELEMENT_DELIMITER_POS)
-    let subElementDelimiter = edi.charAt(SUBELEMENT_DELIMITER_POS)
-
-    if (options === undefined) {
-      options = defaultSerializationOptions({
-        segmentTerminator,
-        elementDelimiter,
-        subElementDelimiter
-      })
-    } else {
-      options = defaultSerializationOptions(options)
-      segmentTerminator = options.segmentTerminator
-      elementDelimiter = options.elementDelimiter
-      subElementDelimiter = options.subElementDelimiter
-    }
-
+  private _validateIsaLength (edi: string, elementDelimiter: string): void {
     if (edi.charAt(103) !== elementDelimiter) {
       const errorMessage = 'X12 Standard: The ISA segment is not the correct length (106 characters, including segment terminator).'
 
@@ -79,120 +132,24 @@ export class X12Parser {
 
       this.diagnostics.push(new X12Diagnostic(X12DiagnosticLevel.Error, errorMessage, new Range(0, 0, 0, 2)))
     }
+  }
 
-    let fatInterchange: X12FatInterchange
-    let interchange: X12Interchange
-    let group: X12FunctionalGroup
-    let transaction: X12Transaction
+  private _detectOptions (edi: string, options?: X12SerializationOptions): void {
+    const segmentTerminator = edi.charAt(SEGMENT_TERMINATOR_POS)
+    const elementDelimiter = edi.charAt(ELEMENT_DELIMITER_POS)
+    const subElementDelimiter = edi.charAt(SUBELEMENT_DELIMITER_POS)
+    const repetitionDelimiter = edi.charAt(REPETITION_DELIMITER_POS)
 
-    const segments = this._parseSegments(edi, segmentTerminator, elementDelimiter)
-
-    segments.forEach((seg) => {
-      if (seg.tag === 'ISA') {
-        if (this._strict && interchange !== undefined && interchange.header !== undefined) {
-          if (fatInterchange === undefined) {
-            fatInterchange = new X12FatInterchange(options)
-            fatInterchange.interchanges.push(interchange)
-          }
-
-          interchange = new X12Interchange(options)
-        }
-
-        if (interchange === undefined) {
-          interchange = new X12Interchange(options)
-        }
-
-        this._processISA(interchange, seg)
-      } else if (seg.tag === 'IEA') {
-        this._processIEA(interchange, seg)
-
-        if (fatInterchange !== undefined) {
-          fatInterchange.interchanges.push(interchange)
-        }
-      } else if (seg.tag === 'GS') {
-        group = new X12FunctionalGroup()
-
-        this._processGS(group, seg)
-        interchange.functionalGroups.push(group)
-      } else if (seg.tag === 'GE') {
-        if (group === undefined) {
-          const errorMessage = 'X12 Standard: Missing GS segment!'
-
-          if (this._strict) {
-            throw new ParserError(errorMessage)
-          }
-
-          this.diagnostics.push(new X12Diagnostic(X12DiagnosticLevel.Error, errorMessage, seg.range))
-        }
-
-        this._processGE(group, seg)
-        group = undefined
-      } else if (seg.tag === 'ST') {
-        if (group === undefined) {
-          const errorMessage = `X12 Standard: ${seg.tag} segment cannot appear outside of a functional group.`
-
-          if (this._strict) {
-            throw new ParserError(errorMessage)
-          }
-
-          this.diagnostics.push(new X12Diagnostic(X12DiagnosticLevel.Error, errorMessage, seg.range))
-        }
-
-        transaction = new X12Transaction()
-
-        this._processST(transaction, seg)
-        group.transactions.push(transaction)
-      } else if (seg.tag === 'SE') {
-        if (group === undefined) {
-          const errorMessage = `X12 Standard: ${seg.tag} segment cannot appear outside of a functional group.`
-
-          if (this._strict) {
-            throw new ParserError(errorMessage)
-          }
-
-          this.diagnostics.push(new X12Diagnostic(X12DiagnosticLevel.Error, errorMessage, seg.range))
-        }
-
-        if (transaction === undefined) {
-          const errorMessage = 'X12 Standard: Missing ST segment!'
-
-          if (this._strict) {
-            throw new ParserError(errorMessage)
-          }
-
-          this.diagnostics.push(new X12Diagnostic(X12DiagnosticLevel.Error, errorMessage, seg.range))
-        }
-
-        this._processSE(transaction, seg)
-        transaction = undefined
-      } else {
-        if (group === undefined) {
-          const errorMessage = `X12 Standard: ${seg.tag} segment cannot appear outside of a functional group.`
-
-          if (this._strict) {
-            throw new ParserError(errorMessage)
-          }
-
-          this.diagnostics.push(new X12Diagnostic(X12DiagnosticLevel.Error, errorMessage, seg.range))
-        }
-
-        if (transaction === undefined) {
-          const errorMessage = `X12 Standard: ${seg.tag} segment cannot appear outside of a transaction.`
-
-          if (this._strict) {
-            throw new ParserError(errorMessage)
-          }
-
-          this.diagnostics.push(new X12Diagnostic(X12DiagnosticLevel.Error, errorMessage, seg.range))
-        } else {
-          transaction.segments.push(seg)
-        }
-      }
-    })
-
-    return fatInterchange === undefined
-      ? interchange
-      : fatInterchange
+    if (options === undefined) {
+      this._options = defaultSerializationOptions({
+        segmentTerminator,
+        elementDelimiter,
+        subElementDelimiter,
+        repetitionDelimiter
+      })
+    } else {
+      this._options = defaultSerializationOptions(options)
+    }
   }
 
   private _parseSegments (edi: string, segmentTerminator: string, elementDelimiter: string): X12Segment[] {
@@ -260,6 +217,110 @@ export class X12Parser {
     }
 
     return segments
+  }
+
+  private _processSegment (seg: X12Segment): void {
+    if (seg.tag === 'ISA') {
+      if (this._strict && this._interchange !== undefined && this._interchange.header !== undefined) {
+        if (this._fatInterchange === undefined) {
+          this._fatInterchange = new X12FatInterchange(this._options)
+          this._fatInterchange.interchanges.push(this._interchange)
+        }
+
+        this._interchange = new X12Interchange(this._options)
+      }
+
+      if (this._interchange === undefined) {
+        this._interchange = new X12Interchange(this._options)
+      }
+
+      this._processISA(this._interchange, seg)
+      this._parsedISA = true
+    } else if (seg.tag === 'IEA') {
+      this._processIEA(this._interchange, seg)
+
+      if (this._fatInterchange !== undefined) {
+        this._fatInterchange.interchanges.push(this._interchange)
+      }
+    } else if (seg.tag === 'GS') {
+      this._group = new X12FunctionalGroup(this._options)
+
+      this._processGS(this._group, seg)
+      this._interchange.functionalGroups.push(this._group)
+    } else if (seg.tag === 'GE') {
+      if (this._group === undefined) {
+        const errorMessage = 'X12 Standard: Missing GS segment!'
+
+        if (this._strict) {
+          throw new ParserError(errorMessage)
+        }
+
+        this.diagnostics.push(new X12Diagnostic(X12DiagnosticLevel.Error, errorMessage, seg.range))
+      }
+
+      this._processGE(this._group, seg)
+      this._group = undefined
+    } else if (seg.tag === 'ST') {
+      if (this._group === undefined) {
+        const errorMessage = `X12 Standard: ${seg.tag} segment cannot appear outside of a functional group.`
+
+        if (this._strict) {
+          throw new ParserError(errorMessage)
+        }
+
+        this.diagnostics.push(new X12Diagnostic(X12DiagnosticLevel.Error, errorMessage, seg.range))
+      }
+
+      this._transaction = new X12Transaction(this._options)
+
+      this._processST(this._transaction, seg)
+      this._group.transactions.push(this._transaction)
+    } else if (seg.tag === 'SE') {
+      if (this._group === undefined) {
+        const errorMessage = `X12 Standard: ${seg.tag} segment cannot appear outside of a functional group.`
+
+        if (this._strict) {
+          throw new ParserError(errorMessage)
+        }
+
+        this.diagnostics.push(new X12Diagnostic(X12DiagnosticLevel.Error, errorMessage, seg.range))
+      }
+
+      if (this._transaction === undefined) {
+        const errorMessage = 'X12 Standard: Missing ST segment!'
+
+        if (this._strict) {
+          throw new ParserError(errorMessage)
+        }
+
+        this.diagnostics.push(new X12Diagnostic(X12DiagnosticLevel.Error, errorMessage, seg.range))
+      }
+
+      this._processSE(this._transaction, seg)
+      this._transaction = undefined
+    } else {
+      if (this._group === undefined) {
+        const errorMessage = `X12 Standard: ${seg.tag} segment cannot appear outside of a functional group.`
+
+        if (this._strict) {
+          throw new ParserError(errorMessage)
+        }
+
+        this.diagnostics.push(new X12Diagnostic(X12DiagnosticLevel.Error, errorMessage, seg.range))
+      }
+
+      if (this._transaction === undefined) {
+        const errorMessage = `X12 Standard: ${seg.tag} segment cannot appear outside of a transaction.`
+
+        if (this._strict) {
+          throw new ParserError(errorMessage)
+        }
+
+        this.diagnostics.push(new X12Diagnostic(X12DiagnosticLevel.Error, errorMessage, seg.range))
+      } else {
+        this._transaction.segments.push(seg)
+      }
+    }
   }
 
   private _processISA (interchange: X12Interchange, segment: X12Segment): void {
@@ -346,5 +407,66 @@ export class X12Parser {
 
       this.diagnostics.push(new X12Diagnostic(X12DiagnosticLevel.Error, errorMessage, segment.elements[1].range))
     }
+  }
+
+  private _consumeChunk (chunk: string): void {
+    chunk = this._dataCache + chunk
+    let rawSegments: string[]
+
+    if (!this._parsedISA && chunk.length >= DOCUMENT_MIN_LENGTH) {
+      this._detectOptions(chunk, this._options)
+
+      this._validateIsaLength(chunk, this._options.elementDelimiter)
+
+      rawSegments = chunk.split(this._options.segmentTerminator)
+
+      if (chunk.charAt(chunk.length - 1) !== this._options.segmentTerminator) {
+        this._dataCache = rawSegments[rawSegments.length - 1]
+        rawSegments.splice(rawSegments.length - 1, 1)
+      }
+    }
+
+    if (this._parsedISA) {
+      rawSegments = chunk.split(this._options.segmentTerminator)
+
+      if (chunk.charAt(chunk.length - 1) !== this._options.segmentTerminator && !this._flushing) {
+        this._dataCache = rawSegments[rawSegments.length - 1]
+        rawSegments.splice(rawSegments.length - 1, 1)
+      }
+    }
+
+    if (Array.isArray(rawSegments)) {
+      for (let i = 0; i < rawSegments.length; i += 1) {
+        const segments = this._parseSegments(rawSegments[i] + this._options.segmentTerminator, this._options.segmentTerminator, this._options.elementDelimiter)
+
+        segments.forEach((segment) => {
+          this.push(segment)
+        })
+      }
+    }
+  }
+
+  /**
+   * @description Flush method for Node API Transform stream.
+   * @param {Function} callback - Callback to execute when finished.
+   */
+  public _flush (callback: Function): void {
+    this._flushing = true
+    this._consumeChunk(this._dataCache)
+    this._flushing = false
+
+    callback.call(this)
+  }
+
+  /**
+   * @description Transform method for Node API Transform stream.
+   * @param {object} chunk - A chunk of data from the read stream.
+   * @param {string} encoding - Chunk enoding.
+   * @param {Function} callback - Callback signalling chunk is processed and instance is ready for next chunk.
+   */
+  public _transform (chunk: any, encoding: string, callback: Function): void {
+    this._consumeChunk(this._decoder.write(chunk))
+
+    callback.call(this)
   }
 }

--- a/src/X12SerializationOptions.ts
+++ b/src/X12SerializationOptions.ts
@@ -15,6 +15,7 @@ export interface X12SerializationOptions {
   format?: boolean
   segmentTerminator?: string
   subElementDelimiter?: string
+  repetitionDelimiter?: string
 }
 
 /**
@@ -30,6 +31,7 @@ export function defaultSerializationOptions (options?: X12SerializationOptions):
   options.format = options.format === undefined ? false : options.format
   options.segmentTerminator = options.segmentTerminator === undefined ? '~' : options.segmentTerminator
   options.subElementDelimiter = options.subElementDelimiter === undefined ? '>' : options.subElementDelimiter
+  options.repetitionDelimiter = options.repetitionDelimiter === undefined ? '^' : options.repetitionDelimiter
 
   if (options.segmentTerminator === '\n') {
     options.endOfLine = ''

--- a/src/X12Transaction.ts
+++ b/src/X12Transaction.ts
@@ -67,8 +67,7 @@ export class X12Transaction {
    * @description Map data from a javascript object to this transaction set.
    * @param {object} input - The input object to create the transaction from.
    * @param {object} map - The javascript object containing keys and querys to resolve.
-   * @param {object} [macroObj] - A macro object to add or override methods for the macro directive; properties 'header' and 'segments' are reserved words.
-   * @returns {object} An object containing resolved values mapped to object keys.
+   * @param {object} [macro] - A macro object to add or override methods for the macro directive; properties 'header' and 'segments' are reserved words.
    */
   fromObject (input: any, map: any, macro?: any): void {
     const mapper = new X12TransactionMap(map, this)

--- a/test/ParserSuite.ts
+++ b/test/ParserSuite.ts
@@ -18,6 +18,38 @@ describe('X12Parser', () => {
     parser.parse(edi)
   })
 
+  it('should parse and reconstruct a valid X12 stream without throwing an error', async () => {
+    return new Promise((resolve, reject) => {
+      const ediStream = fs.createReadStream('test/test-data/850.edi', 'utf8')
+      const parser = new X12Parser()
+      const segments: X12Segment[] = []
+
+      ediStream.on('error', (error) => {
+        reject(error)
+      })
+
+      parser.on('error', (error) => {
+        reject(error)
+      })
+
+      ediStream.pipe(parser).on('data', (data) => {
+        segments.push(data)
+      })
+        .on('end', () => {
+          const edi = fs.readFileSync('test/test-data/850.edi', 'utf8')
+          const interchange = parser.getInterchangeFromSegments(segments)
+
+          interchange.options.format = true
+          interchange.options.endOfLine = '\n'
+
+          if (interchange.toString() !== edi) {
+            reject(new Error('Expected parsed EDI stream to match raw EDI document.'))
+          }
+          resolve()
+        })
+    })
+  })
+
   it('should produce accurate line numbers for files with line breaks', () => {
     const edi = fs.readFileSync('test/test-data/850_3.edi', 'utf8')
     const parser = new X12Parser()


### PR DESCRIPTION
- Resolves enhancement for issue #1 
- Fixes syntax issue in JSDoc comments
- Tests passing, no breaking changes found

The capability to treat an EDI document as a stream should reduce memory overhead of standard parser function.