### PR TITLE
Update ST header layout

### DIFF
--- a/src/X12SegmentHeader.ts
+++ b/src/X12SegmentHeader.ts
@@ -61,7 +61,9 @@ export const STSegmentHeader: X12SegmentHeader = {
     ST01: 3,
     ST02: 9,
     ST02_MIN: 4,
-    COUNT: 2,
+    ST03: 1,
+    ST03_MIN: 35,
+    COUNT: 3,
     PADDING: false
   }
 }


### PR DESCRIPTION
Add support for ST03 element (Implementation Convention Reference)

I'm working with a TP who requires the ST03 element for validation, but adding that element causes a validation error because it's not in the layout.   I've added it manually in my own project but thought it could be helpful to submit here, too.