### PR TITLE
Fix handling of ST header with 3 elements

### DIFF
--- a/src/X12Segment.ts
+++ b/src/X12Segment.ts
@@ -241,9 +241,9 @@ export class X12Segment {
         }
       } else {
         throw new GeneratorError(
-          typeof enumerable.COUNT === 'number'
-            ? `Segment "${this.tag}" with ${values.length} elements does meet the required count of min ${enumerable.COUNT_MIN} or max ${enumerable.COUNT}.`
-            : `Segment "${this.tag}" with ${values.length} elements does meet the required count of ${enumerable.COUNT}.`
+          typeof enumerable.COUNT_MIN === 'number'
+            ? `Segment "${this.tag}" with ${values.length} elements does not meet the required count of min ${enumerable.COUNT_MIN} or max ${enumerable.COUNT}.`
+            : `Segment "${this.tag}" with ${values.length} elements does not meet the required count of ${enumerable.COUNT}.`
         )
       }
     }

--- a/src/X12Segment.ts
+++ b/src/X12Segment.ts
@@ -208,7 +208,7 @@ export class X12Segment {
         values[15] = this.options.subElementDelimiter
       }
 
-      if (values.length === enumerable.COUNT) {
+      if (values.length === enumerable.COUNT || values.length === enumerable.COUNT_MIN) {
         for (let i = 0; i < values.length; i++) {
           const name = `${this.tag}${String.prototype.padStart.call(i + 1, 2, '0')}`
           const max = enumerable[name]
@@ -241,7 +241,9 @@ export class X12Segment {
         }
       } else {
         throw new GeneratorError(
-          `Segment "${this.tag}" with ${values.length} elements does meet the required count of ${enumerable.COUNT}.`
+          typeof enumerable.COUNT === 'number'
+            ? `Segment "${this.tag}" with ${values.length} elements does meet the required count of min ${enumerable.COUNT_MIN} or max ${enumerable.COUNT}.`
+            : `Segment "${this.tag}" with ${values.length} elements does meet the required count of ${enumerable.COUNT}.`
         )
       }
     }

--- a/src/X12SegmentHeader.ts
+++ b/src/X12SegmentHeader.ts
@@ -61,7 +61,9 @@ export const STSegmentHeader: X12SegmentHeader = {
     ST01: 3,
     ST02: 9,
     ST02_MIN: 4,
-    COUNT: 2,
+    ST03: 1,
+    ST03_MIN: 35,
+    COUNT: 3,
     PADDING: false
   }
 }

--- a/src/X12SegmentHeader.ts
+++ b/src/X12SegmentHeader.ts
@@ -61,9 +61,10 @@ export const STSegmentHeader: X12SegmentHeader = {
     ST01: 3,
     ST02: 9,
     ST02_MIN: 4,
-    ST03: 1,
-    ST03_MIN: 35,
+    ST03: 35,
+    ST03_MIN: 1,
     COUNT: 3,
+    COUNT_MIN: 2,
     PADDING: false
   }
 }

--- a/test/GeneratorSuite.ts
+++ b/test/GeneratorSuite.ts
@@ -48,7 +48,7 @@ describe('X12Generator', () => {
     }
   })
 
-  it('should not generate 271 with 3 ST elements using default segment headers', () => {
+  it('should not generate 271 with 4 ST elements using default segment headers', () => {
     const fileEdi = fs.readFileSync('test/test-data/271.edi', 'utf8').split('~')
 
     const i = new X12Interchange()
@@ -63,13 +63,13 @@ describe('X12Generator', () => {
 
     let error
     try {
-      t.setHeader(fileEdi[2].split('*').slice(1))
+      t.setHeader([...fileEdi[2].split('*').slice(1), 'N'])
     } catch (err) {
       error = err.message
     }
 
-    if (error !== 'Segment "ST" with 3 elements does meet the required count of 2.') {
-      throw new Error('271 with 3 ST elements parsing succeed which should not happen')
+    if (error !== 'Segment "ST" with 4 elements does not meet the required count of min 2 or max 3.') {
+      throw new Error('271 with 4 ST elements parsing succeed which should not happen')
     }
   })
 
@@ -153,7 +153,7 @@ describe('X12Generator', () => {
       error = err.message
     }
 
-    if (error !== 'Segment "HL" with 4 elements does meet the required count of 3.') {
+    if (error !== 'Segment "HL" with 4 elements does not meet the required count of 3.') {
       throw new Error('271 with custom segment headers parsing succeed which should not happen')
     }
   })


### PR DESCRIPTION
A lot of industries may expect 2 OR 3 elements in segment ST. This adds default support for that.